### PR TITLE
Class::Autouse issue; don't always load File::Slurp, JSON, YAML & LWP

### DIFF
--- a/bin/p
+++ b/bin/p
@@ -3,32 +3,33 @@ use strict;
 use warnings;
 use Pod::Usage;
 
+# VERSION
+
 pod2usage() unless @ARGV;
 
 unshift @ARGV, '-E' if @ARGV == 1;
 
 exec
-    'perl',
-    '-Mwarnings',
-    '-MClass::Autouse=:superloader',
+    $^X,
+    '-Mwarnings=all',
+    '-M-warnings=deprecated',
+    '-ML',
     '-MData::Dump',
-    '-MFile::Slurp',
-    '-MJSON::XS',
     '-MList::AllUtils=:all',
-    '-MLWP::Simple',
+    (grep { /\b(?:get(?:print|store)?|head|mirror)\b/x } @ARGV)
+        ? ('-MLWP::Simple')
+        : (),
     '-Mutf8::all',
-    '-MXML::Hash::LX',
-    '-MYAML::XS',
     '-E',
     q[BEGIN {
-        sub r  { scalar read_file shift }
-        sub w  { write_file @_          }
+        sub r  { scalar File::Slurp::read_file(shift) }
+        sub w  { File::Slurp::write_file(@_)          }
         sub S  { say @_ ? @_ : $_       }
         sub p  { print @_ ? @_ : $_     }
-        sub yd { print Dump(shift)      }
-        sub yl { Load(shift)            }
-        sub xd { print hash2xml(shift)  }
-        sub xl { xml2hash(shift)        }
+        sub yd { print YAML::XS::Dump(shift)          }
+        sub yl { YAML::XS::Load(shift)                }
+        sub xd { print XML::Hash::LX::hash2xml(shift) }
+        sub xl { XML::Hash::LX::xml2hash(shift)       }
         sub jd { print JSON::XS->new->utf8->pretty->encode(shift) }
         sub jl { JSON::XS->new->utf8->allow_nonref->decode(shift) }
     }], @ARGV;
@@ -65,6 +66,6 @@ exec
     p 'dd ExtUtils::Installed->new->modules' # list all installed modules
     p '  dd xl r "/etc/xml/xml-core.xml"'    # print dump of hash converted xml
     p 'p xd xl r "/etc/xml/xml-core.xml"'    # print xml converted from hash
-    p 'p get "http://icanhazip.com"'         # print contents of url
+    p 'getprint "http://icanhazip.com"'      # print contents of url
 
 =cut

--- a/dist.ini
+++ b/dist.ini
@@ -7,16 +7,17 @@ copyright_year   = 2011
 version = 0.0302
 
 [Prereqs]
-Class::Autouse = 0
 Data::Dump     = 0
 File::Slurp    = 0
 JSON::XS       = 0
-List::AllUtils = 0
+L              = 0
 LWP::Simple    = 0
+List::AllUtils = 0
 Pod::Usage     = 0
-utf8::all      = 0
+Scalar::Util   = 0
 XML::Hash::LX  = 0
 YAML::XS       = 0
+utf8::all      = 0
 
 [MetaResources]
 bugtracker.web  = http://github.com/ironcamel/App-p/issues


### PR DESCRIPTION
I've noticed the following `superloader` issue:

```
stas@bp0907:~/App-p$ bin/p 'S DateTime->today'
Can't locate DateTime/Infinite/Future.pm in @INC (...)
```

So I tried to replace it with the shiny new [L](https://metacpan.org/module/L). Also realized that this mechanism can be used for dynamically loading of JSON::XS, YAML::XS, LWP::Simple and even File::Slurp. The advantage if this approach is a noticeable memory footprint reduction (and faster load time).

Original:

```
stas@bp0907:~/App-p$ "time" bin/p 'dd \%INC' | wc -l
0.14user 0.00system 0:00.15elapsed 98%CPU (0avgtext+0avgdata 63312maxresident)k
0inputs+0outputs (0major+5947minor)pagefaults 0swaps
92
```

Dynamic:

```
stas@bp0907:~/App-p$ "time" bin/p 'dd \%INC' | wc -l
0.07user 0.00system 0:00.08elapsed 100%CPU (0avgtext+0avgdata 26336maxresident)k
0inputs+0outputs (0major+3461minor)pagefaults 0swaps
46
```

Bare perl, just for comparison:

```
stas@bp0907:~/App-p$ "time" perl -MData::Dump -E 'dd \%INC' | wc -l
0.00user 0.00system 0:00.01elapsed 85%CPU (0avgtext+0avgdata 11168maxresident)k
0inputs+0outputs (0major+762minor)pagefaults 0swaps
12
```
