### PR TITLE
fixed jd/xd/yd double-encoding UTF-8

### DIFF
--- a/bin/p
+++ b/bin/p
@@ -26,12 +26,12 @@ exec
         sub w  { File::Slurp::write_file(@_)          }
         sub S  { say @_ ? @_ : $_       }
         sub p  { print @_ ? @_ : $_     }
-        sub yd { print YAML::XS::Dump(shift)          }
-        sub yl { YAML::XS::Load(shift)                }
-        sub xd { print XML::Hash::LX::hash2xml(shift) }
-        sub xl { XML::Hash::LX::xml2hash(shift)       }
-        sub jd { print JSON::XS->new->utf8->pretty->encode(shift) }
-        sub jl { JSON::XS->new->utf8->allow_nonref->decode(shift) }
+        sub yd { print Encode::decode_utf8(YAML::XS::Dump(shift))                       }
+        sub yl { YAML::XS::Load(shift)                                                  }
+        sub xd { print Encode::decode_utf8(XML::Hash::LX::hash2xml(shift))              }
+        sub xl { XML::Hash::LX::xml2hash(shift)                                         }
+        sub jd { print Encode::decode_utf8(JSON::XS->new->utf8->pretty->encode(shift))  }
+        sub jl { JSON::XS->new->utf8->allow_nonref->decode(shift)                       }
     }], @ARGV;
 
 


### PR DESCRIPTION
Buggy output:

```
$ p '$x={n=>uc"Станислав"};jd$x;xd$x;yd$x'
{
   "n" : "Ð¡Ð¢ÐÐÐÐ¡ÐÐÐ"
}
<?xml version="1.0" encoding="utf-8"?>
<n>Ð¡Ð¢ÐÐÐÐ¡ÐÐÐ</n>

---
n: Ð¡Ð¢ÐÐÐÐ¡ÐÐÐ
```

The expected output:

```
$ p '$x={n=>uc"Станислав"};jd$x;xd$x;yd$x'
{
   "n" : "СТАНИСЛАВ"
}
<?xml version="1.0" encoding="utf-8"?>
<n>СТАНИСЛАВ</n>

---
n: СТАНИСЛАВ
```

The problem is that functions wrapped by jd/xd/yd do return octets, not Unicode stream, while `print` in combination with `utf8::all` treat everything as an Unicode stream.
